### PR TITLE
Fix: Get redux user info(email)

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.auth, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.email, token: action.payload.token }
+            return { ...state, email: action.payload.auth, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
1. Change `action.payload.login` to `action.payload.email` in reducer file.

## Purpose
Obtain user info(email) from `state`. 

## Approach
Fix error in `authReducer`.

## Testing Steps

1.  Go to `http://localhost:3000/` and login.
2. Navigate to order form and place order.
3. Go to View Orders. 
4. Find the most recent order. It should display user's email instead of `Unknown!`.

Closes #4
